### PR TITLE
READY : Improve workflow, run workflows concurrently without wrong cancelling

### DIFF
--- a/.github/workflows/StandardRustPullRequest.yml
+++ b/.github/workflows/StandardRustPullRequest.yml
@@ -7,7 +7,7 @@ env :
   CARGO_TERM_COLOR : always
 
 concurrency :
-  group : standard_rust_pull_request_${{ github.base_ref }}
+  group : standard_rust_pull_request_${{ github.event.base.ref }}_${{ github.event.number }}
   cancel-in-progress : true
 
 jobs :
@@ -46,5 +46,5 @@ jobs :
     uses : Wandalen/RustModuleCdCi/.github/workflows/StandardRustPush.yml@master
     with :
       manifest_path : './Cargo.toml'
-      module_name : ${{ needs.check.outputs.commit_message }}
-      commit_message : ${{ needs.check.outputs.commit_message }}
+      module_name : ${{ github.event.base.ref }}_${{ github.event.number }}
+      commit_message : ${{ github.event.base.ref }}_${{ github.event.number }}

--- a/.github/workflows/StandardRustPush.yml
+++ b/.github/workflows/StandardRustPush.yml
@@ -17,7 +17,7 @@ on :
 
 concurrency :
 
-  group : standard_rust_push_${{ inputs.module_name }}_${{ github.ref }}
+  group : standard_rust_push_${{ inputs.module_name }}_${{ github.ref }}_${{ contains( inputs.commit_message, '!test' ) || startsWith( inputs.commit_message, 'Merge' ) || contains( inputs.commit_message, inputs.module_name ) }}_${{ !contains( inputs.commit_message, '!only_js' )}}
   cancel-in-progress : true
 
 env :

--- a/.github/workflows/StandardRustPush.yml
+++ b/.github/workflows/StandardRustPush.yml
@@ -17,7 +17,9 @@ on :
 
 concurrency :
 
-  group : standard_rust_push_${{ inputs.module_name }}_${{ github.ref }}_${{ contains( inputs.commit_message, '!test' ) || startsWith( inputs.commit_message, 'Merge' ) || contains( inputs.commit_message, inputs.module_name ) }}_${{ !contains( inputs.commit_message, '!only_js' )}}
+  group : standard_rust_push_${{ inputs.module_name }}_${{ github.ref }}_
+    ${{ contains( inputs.commit_message, '!test' ) || startsWith( inputs.commit_message, 'Merge' ) || contains( inputs.commit_message, inputs.module_name ) }}_
+    ${{ !contains( inputs.commit_message, '!only_js' )}}
   cancel-in-progress : true
 
 env :


### PR DESCRIPTION
It's minimal change, that provides needed functionality : 
- run test if commit message has `!test` or `Merge` or module name and has not directive `!only_js`
- cancel single run of individual module if commit message has name of module 
- cancel all previous runs if commit message has `!test` or `Merge` 
- cancel no runs if commit message has no keywords or has keyword `!only_js` 

Example of commit sequence 
https://github.com/dmvict/CiCdTemplate/actions?query=branch%3Aexp_test ( please, call me, if it needs )